### PR TITLE
feat: volume finder

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Compile image collections into PDF chapters and volumes.
   - convert -> merge
   - extract -> convert -> merge
 - Transactional output behavior: results are staged first and moved to the destination only on success.
-- If an error occurs during processing (e.g., invalid file format), log the error and continue to the next item instead of aborting.
+- Skip flag: if an error occurs during processing (e.g., invalid file format), log the error and continue to the next item instead of aborting.
+- Verbose flag: enables detailed output after scraping.
 
 ## Installation
 
@@ -55,14 +56,16 @@ python3 meowdfer.py -h
 
 CLI syntax:
 ```sh
-python3 meowdfer.py (-e SRC DEST | -c SRC DEST | -m SRC DEST | -cm SRC DEST | -a SRC DEST) [-v VOLS] [-n NAME] [-s]
+python3 meowdfer.py (-e SRC DEST | -c SRC DEST | -m SRC DEST | -cm SRC DEST | -a SRC DEST | -sc NAME DEST) [-f FILE] [-n NAME] [-s] [-v]
 ```
 
 Notes:
 
 - `DEST` is created if it does not exist.
 - `--name` is optional and controls output PDF names.
-- `--vols` is required for `--merge`, `--convert-merge`, and `--all`.
+- `--file` is required for `--merge`, `--convert-merge`, and `--all`.
+- `--skip` continues to the next item instead of aborting on error.
+- `--verbose` enables detailed output after scraping.
 
 ### Extract
 
@@ -90,19 +93,19 @@ python3 meowdfer.py --convert <img_folders> <out_folder> --name example
 ```
 
 ```sh
-python3 meowdfer.py --merge <pdf_folder> <out_folder> --vols ./vols.txt --name example
+python3 meowdfer.py --merge <pdf_folder> <out_folder> --file ./vols.txt --name example
 ```
 
 ### Pipelines
 
 Convert -> Merge:
 ```sh
-python3 meowdfer.py --convert-merge <img_folders> <out_folder> --vols ./vols.txt --name example
+python3 meowdfer.py --convert-merge <img_folders> <out_folder> --file ./vols.txt --name example
 ```
 
 Extract -> Convert -> Merge:
 ```sh
-python3 meowdfer.py --all <zips_folder> <out_folder> --vols ./vols.txt --name example
+python3 meowdfer.py --all <zips_folder> <out_folder> --file ./vols.txt --name example
 ```
 
 ## CLI Options
@@ -111,15 +114,17 @@ python3 meowdfer.py --all <zips_folder> <out_folder> --vols ./vols.txt --name ex
 |---|---|
 | `-e`, `--extract SRC DEST` | Extract many `.zip` files from `SRC` into `DEST`. |
 | `-c`, `--convert SRC DEST` | Convert image folders into chapter PDFs. |
-| `-m`, `--merge SRC DEST` | Merge chapter PDFs into volumes based on `vols.txt`. |
+| `-m`, `--merge SRC DEST` | Merge chapter PDFs into volumes based on volume interval file. |
 | `-cm`, `--convert-merge SRC DEST` | Pipeline: convert and merge. |
 | `-a`, `--all SRC DEST` | Pipeline: extract, convert, and merge. |
+| `-sc`, `--scrape NAME DEST` | Scrape wikipedia for finding the chapters intervals of a manga. |
 
 | Data flag | Description |
 |---|---|
-| `-v`, `--vols VOLS` | File with increasing chapter cutoffs (required for merge pipelines). |
+| `-f`, `--file FILE` | File with increasing chapter cutoffs (required for merge pipelines). |
 | `-n`, `--name NAME` | Override base output name (otherwise uses destination folder name). |
 | `-s`, `--skip` | On error during processing, log continue to the next item instead of aborting. | 
+| `-v`, `--verbose` | Enable detailed output after scraping. |
 
 ## Running Tests
 
@@ -147,6 +152,8 @@ Workflow file: `.github/workflows/ci.yml`
 - Pillow
 - pypdf
 - rich
+- requests
+- beautifulsoup4
 - pytest (dev)
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Compile image collections into PDF chapters and volumes.
   - extract -> convert -> merge
 - Transactional output behavior: results are staged first and moved to the destination only on success.
 - Skip flag: if an error occurs during processing (e.g., invalid file format), log the error and continue to the next item instead of aborting.
-- Verbose flag: enables detailed output after scraping.
+- Verbose flag: enables detailed output after scraping. (source)
 
 ## Installation
 
@@ -64,8 +64,8 @@ Notes:
 - `DEST` is created if it does not exist.
 - `--name` is optional and controls output PDF names.
 - `--file` is required for `--merge`, `--convert-merge`, and `--all`.
-- `--skip` continues to the next item instead of aborting on error.
-- `--verbose` enables detailed output after scraping.
+- `--skip` continues to the next item instead of aborting on error. (extract, convert, merge, pipelines)
+- `--verbose` enables detailed output after scraping. (scrape)
 
 ### Extract
 
@@ -106,6 +106,13 @@ python3 meowdfer.py --convert-merge <img_folders> <out_folder> --file ./vols.txt
 Extract -> Convert -> Merge:
 ```sh
 python3 meowdfer.py --all <zips_folder> <out_folder> --file ./vols.txt --name example
+```
+
+### Scrape 
+scrapes wikipedia for finding the chapters intervals of a manga.
+
+```sh
+python3 meowdfer.py --scrape <name> <out_file>
 ```
 
 ## CLI Options

--- a/README.md
+++ b/README.md
@@ -34,6 +34,18 @@ source .venv/bin/activate
 pip install -e .
 ```
 
+Alternatively:
+
+2. Make script executable:
+```sh
+chmod +x meowdfer.py
+```
+
+3. Run it as executable:
+```sh
+./meowdfer.py -h
+```
+
 ## Usage
 
 Show help:

--- a/meowdfer.py
+++ b/meowdfer.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or

--- a/meowdfer.py
+++ b/meowdfer.py
@@ -33,20 +33,24 @@ def initiate():
     action_group = parser.add_mutually_exclusive_group(required=True)
     action_group.add_argument("-e", "--extract", nargs=2, metavar=("SRC", "DEST"), help="extract zip files.")
     action_group.add_argument("-c", "--convert", nargs=2, metavar=("SRC", "DEST"), help="convert image folders to PDFs.")
-    action_group.add_argument("-m", "--merge", nargs=2, metavar=("SRC", "DEST"), help="merge PDFs based on vols.txt.")
+    action_group.add_argument("-m", "--merge", nargs=2, metavar=("SRC", "DEST"), help="merge PDFs based on a file with volume intervals (requires -f/--file).")
     action_group.add_argument("-a", "--all", nargs=2, metavar=("SRC", "DEST"), help="full pipeline: extract -> convert -> merge.")
     action_group.add_argument("-cm", "--convert-merge", nargs=2, metavar=("SRC", "DEST"), help="half pipeline: convert -> merge.")
     action_group.add_argument("-sc", "--scrape", nargs=2, metavar=("NAME", "DEST"), help="scrape wikipedia for finding the chapters intervals of a manga.")
 
     # data flags  
-    parser.add_argument("-v", "--vols", metavar="VOLS", help="path to vols.txt (Required for merge, all, convert-merge).")
+    parser.add_argument("-f", "--file", metavar="FILE", help="name of file with intervals for volumes (Required for merge, all, convert-merge).")
     parser.add_argument("-n", "--name", metavar="NAME", help="optional name output (files named differently than dest name).")
     parser.add_argument("-s", "--skip", action="store_true", help="on error during processing, log continue to the next item instead of aborting.")
+    parser.add_argument("-v", "--verbose", action="store_true", help="verbose/detailed output.")
 
     args = parser.parse_args()
 
-    if (args.merge or args.all or args.convert_merge) and not args.vols:
-        parser.error("the --vols/-v argument is required when running merge, all, or convert-merge.")
+    if (args.merge or args.all or args.convert_merge) and not args.file:
+        parser.error("the --file/-f argument is required when running merge, all, or convert-merge.")
+
+    if args.file and not os.path.isfile(args.file):
+        parser.error(f"The file '{args.file}' does not exist.")
 
     return args
 
@@ -149,9 +153,11 @@ def main():
 
         console.print(f"[bold green]Scraping: started[/bold green]")
 
-        with console.status(f"[bold green]Scraping... {name}[/bold green]"):
-            ok = scrape_volumes.run(name, dest, console=console)
-
+        if args.verbose:
+            ok = scrape_volumes.run(name, dest, verbose=True, console=console)
+        else:
+            ok = scrape_volumes.run(name, dest, verbose=False, console=console)
+        
         _finish(
             ok,
             "Scraping: completed!",

--- a/meowdfer.py
+++ b/meowdfer.py
@@ -19,6 +19,7 @@ from src.commands.convert import convert_pdf
 from src.commands.merge import merge_pdf
 from src.commands.convert_merge import convert_merge
 from src.commands.all import extract_convert_merge
+from src.commands.scrape import scrape_volumes
 
 install(show_locals=True)
 
@@ -35,6 +36,7 @@ def initiate():
     action_group.add_argument("-m", "--merge", nargs=2, metavar=("SRC", "DEST"), help="merge PDFs based on vols.txt.")
     action_group.add_argument("-a", "--all", nargs=2, metavar=("SRC", "DEST"), help="full pipeline: extract -> convert -> merge.")
     action_group.add_argument("-cm", "--convert-merge", nargs=2, metavar=("SRC", "DEST"), help="half pipeline: convert -> merge.")
+    action_group.add_argument("-sc", "--scrape", nargs=2, metavar=("NAME", "DEST"), help="scrape wikipedia for finding the chapters intervals of a manga.")
 
     # data flags  
     parser.add_argument("-v", "--vols", metavar="VOLS", help="path to vols.txt (Required for merge, all, convert-merge).")
@@ -140,6 +142,20 @@ def main():
             ok,
             "All pipeline (Extract -> Convert -> Merge): completed!",
             "All pipeline (Extract -> Convert -> Merge) failed: destination was not updated.",
+        )
+    
+    elif args.scrape: 
+        name, dest = args.scrape
+
+        console.print(f"[bold green]Scraping: started[/bold green]")
+
+        with console.status(f"[bold green]Scraping... {name}[/bold green]"):
+            ok = scrape_volumes.run(name, dest, console=console)
+
+        _finish(
+            ok,
+            "Scraping: completed!",
+            "Scraping failed: destination was not updated.",
         )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 name = "meowDFer"
 version = "0.1.0"
 description = "A CLI tool to convert zipped image folders into structured PDFs"
+readme = "README.md"
 requires-python = ">=3.10"
 authors = [
     {name = "v1c3nt"}
@@ -9,17 +10,20 @@ authors = [
 license = {text = "GPL-3.0-only"}
 classifiers = [
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+    "Programming Language :: Python :: 3",
 ]
 
 dependencies = [
     "Pillow", 
     "pypdf",
-    "rich>=13.0.0"
+    "rich>=13.0.0",
+    "requests>=2.31.0",
+    "beautifulsoup4>=4.12.0"
 ]
 
 [project.optional-dependencies]
 dev = [
-    "pytest"
+    "pytest>=7.0.0"
 ]
 
 [project.scripts]

--- a/src/commands/scrape/scrape_volumes.py
+++ b/src/commands/scrape/scrape_volumes.py
@@ -257,26 +257,39 @@ def expand_chapter(raw: str) -> list[str]:
     return [f'{base} ({i})' for i in range(a, b + 1)]
 
 
-def write_output(manga: str, source_url: str, volumes: list[dict], path: str):
+def write_output(manga: str, source_url: str, volumes: list[dict], path: str, verbose: bool = False):
     with open(path, "w", encoding="utf-8") as f:
-        f.write(f"Title: {manga}\n")
-        f.write(f"Source: {source_url}\n\n")
+        if verbose:
+            f.write(f"Title: {manga}\n")
+            f.write(f"Source: {source_url}\n\n")
+        
         global_n = 0
+        endpoints = []
+
         for v in volumes:
             count = sum(len(expand_chapter(ch)) for ch in v["chapters"])
+        
             if count == 0:
-                f.write(f"v{v['volume']}: -\n")
+                if verbose:
+                    f.write(f"volume {v['volume']}: -\n")
                 continue
+            
             start = global_n + 1
             end = global_n + count
             global_n = end
-            if start == end:
-                f.write(f"v{v['volume']}: {start}\n")
+            if verbose:
+                if start == end:
+                    f.write(f"volume {v['volume']}: {start}\n")
+                else:
+                    f.write(f"volume {v['volume']}: {start}-{end}\n")
             else:
-                f.write(f"v{v['volume']}: {start}-{end}\n")
+                endpoints.append(str(end))
+        
+        if not verbose:
+            f.write(", ".join(endpoints))
 
 
-def run(name, dest_path, console):
+def run(name, dest_path, verbose=False, console=None):
     # validate if manga has wikipedia page 
     console.print(f"Validating '{name}' as a manga on Wikipedia...")
     title = validate_manga(name)
@@ -312,6 +325,6 @@ def run(name, dest_path, console):
         return False
     
     out = dest_path or f"{re.sub(r'[^A-Za-z0-9]+', '_', name).strip('_')}_chapters.txt"
-    write_output(title, url, volumes, out)
+    write_output(title, url, volumes, out, verbose)
     console.print(f"Wrote: {out}")
     return True

--- a/src/commands/scrape/scrape_volumes.py
+++ b/src/commands/scrape/scrape_volumes.py
@@ -1,0 +1,317 @@
+from __future__ import annotations
+
+import re
+import sys
+import requests
+import urllib.parse
+
+from bs4 import BeautifulSoup, Tag
+
+UA = "Mozilla/5.0 (manga-scraper; +https://example.org)"
+WIKI = "https://en.wikipedia.org"
+
+session = requests.Session()
+session.headers.update({"User-Agent": UA})
+
+
+def fetch(url: str) -> str:
+    r = session.get(url, timeout=30)
+    r.raise_for_status()
+    return r.text
+
+
+def api_get(params: dict) -> dict:
+    params = {**params, "format": "json"}
+    r = session.get(f"{WIKI}/w/api.php", params=params, timeout=30)
+    r.raise_for_status()
+    return r.json()
+
+
+def validate_manga(name: str) -> str | None:
+    data = api_get({
+        "action": "query",
+        "list": "search",
+        "srsearch": f'"{name}" manga',
+        "srlimit": 8,
+    })
+
+    hits = data.get("query", {}).get("search", [])
+
+    if not hits:
+        return None
+    
+    name_l = name.lower()
+    ordered = sorted(hits, key=lambda h: 0 if name_l in h["title"].lower() else 1)
+    
+    for hit in ordered:
+        title = hit["title"]
+        if _is_manga_page(title):
+            return title
+    
+    return None
+
+
+def _is_manga_page(title: str) -> bool:
+    data = api_get({
+        "action": "query",
+        "prop": "categories|extracts",
+        "titles": title,
+        "exintro": 1,
+        "explaintext": 1,
+        "cllimit": "max",
+    })
+
+    pages = data.get("query", {}).get("pages", [])
+    if not pages:
+        return False
+        
+    page = next(iter(pages.values()))
+    cats = " ".join(c.get("title", "").lower() for c in page.get("categories", []))
+    extract = page.get("extract", "").lower()
+
+    return "manga" in cats or "manga" in extract[:800]
+
+
+def find_chapters_page(name: str, manga_title: str | None = None) -> str | None:
+    if manga_title:
+        linked = _chapters_link_from_article(manga_title)
+        if linked:
+            return linked
+
+    for cand in (
+        f"List of {name} chapters",
+        f"List of {name} manga chapters",
+        f"List of {name} volumes",
+        f"{name} chapters",
+    ):
+        t = _page_exists(cand)
+        if t:
+            return t
+
+    data = api_get({
+        "action": "query",
+        "list": "search",
+        "srsearch": f'intitle:"List of" intitle:"{name}" intitle:chapters',
+        "srlimit": 5,
+    })
+    for hit in data.get("query", {}).get("search", []):
+        title = hit["title"]
+        low = title.lower()
+        if low.startswith("list of") and ("chapter" in low or "volume" in low):
+            return title
+    return None
+
+
+def _chapters_link_from_article(title: str) -> str | None:
+    """Look for a link like 'List of <X> chapters' on the manga's own page."""
+    data = api_get({
+        "action": "query",
+        "prop": "links",
+        "titles": title,
+        "pllimit": "max",
+        "plnamespace": 0,
+    })
+    pages = data.get("query", {}).get("pages", {})
+    if not pages:
+        return None
+    page = next(iter(pages.values()))
+    for link in page.get("links", []):
+        t = link.get("title", "")
+        low = t.lower()
+        if low.startswith("list of") and ("chapter" in low or "volume" in low):
+            resolved = _page_exists(t)
+            if resolved:
+                return resolved
+    return None
+
+
+def _page_exists(title: str) -> str | None:
+    data = api_get({
+        "action": "query",
+        "titles": title,
+        "redirects": 1
+    })
+    
+    pages = data.get("query", {}).get("pages", {})
+    if not pages:
+        return None
+    page = next(iter(pages.values()))
+
+    if "missing" not in page:
+        return page["title"]
+    
+    return None
+
+
+def extract_volumes(html: str) -> list[str]:
+    soup = BeautifulSoup(html, "html.parser")
+
+    for stop_id in ("References", "Notes"):
+        h = soup.find(id=stop_id)
+        if h:
+            anchor = h.parent if h.parent and h.parent.name in ("h1", "h2", "h3", "h4") else h
+            for sib in list(anchor.find_all_next()):
+                sib.decompose()
+            anchor.decompose()
+    
+    for ref in soup.select(".references"):
+        ref.decompose()
+    
+    volumes: list[dict] = []
+    vol_headers = soup.find_all(id=re.compile(r"^vol\d+$"))
+
+    for idx, th in enumerate(vol_headers):
+        m = re.match(r"^vol(\d+)$", th.get("id", ""))
+        if not m:
+            continue
+        
+        vol_num = int(m.group(1))
+        vol_title = f"Volume {vol_num}"
+
+        # volume title: first <td> sibling after the <th>
+        td = th.find_next("td")
+        if td:
+            italic = td.find("i")
+            raw_title = _node_text(italic) if italic else _node_text(td)
+            if not re.match(
+                r'^(?:\d{1,2}\s+\w+\s+\d{4}|\w+\s+\d{1,2},?\s+\d{4}|'
+                r'\d{4}-\d{2}-\d{2}|\d+|ISBN.*)$',
+                raw_title.strip(),
+            ):
+                vol_title = raw_title
+        
+        # find chapter list - next <ol>/<ul> after this th
+        # but stop before next vol header
+
+        next_th = vol_headers[idx + 1] if idx + 1 < len(vol_headers) else None
+        chapters: list[str] = []
+
+        for lst in th.find_all_next(["ol", "ul"]):
+            if next_th is not None and _comes_after(lst, next_th):
+                break
+            classes = " ".join(lst.get("class", [])).lower()
+            if "references" in classes:
+                continue
+            for li in lst.find_all("li"):
+                text = _node_text(li)
+                text = re.sub(r'^\s*\d+(?:\s*[–-]\s*\d+)?\s*\.\s*', '', text)
+                text = text.strip().strip('"').strip()
+                if text:
+                    chapters.append(text)
+
+        volumes.append({
+            "volume": vol_num,
+            "title": vol_title,
+            "chapters": chapters,
+        })
+    
+    return volumes
+
+
+        
+def _node_text(node: Tag) -> str:
+    clone = BeautifulSoup(str(node), "html.parser")
+    
+    for bad in clone.find_all(["sup", "style", "script"]):
+        bad.decompose()
+    
+    for span in clone.find_all("span"):
+        if span.parent is None:
+            continue
+        
+        lang = (span.get("lang") or "").lower()
+        style = (span.get("style") or "").lower()
+        
+        if lang.startswith("ja") or "font-weight: normal" in style:
+            span.decompose()
+
+    return _clean_text(clone.get_text(" "))
+
+
+def _clean_text(s: str) -> str:
+    s = re.sub(r"\[[^\]]*\]", "", s)  # strip [1], [note 2]
+    s = re.sub(r"\s+", " ", s).strip()
+    return s
+
+
+def _comes_after(a: Tag, b: Tag) -> bool:
+    """True if `a` appears after `b` in document order."""
+    for el in b.find_all_next():
+        if el is a:
+            return True
+    return False
+
+
+_RANGE_RE = re.compile(
+    r'^\s*(?:(\d+)\s*[–-]\s*(\d+)\s*\.\s*)?"?\s*(.+?)\s*\((\d+)\s*[–-]\s*(\d+)\)\s*"?\s*$'
+)
+
+def expand_chapter(raw: str) -> list[str]:
+    m = _RANGE_RE.match(raw)
+    if not m:
+        return [raw]
+    base = m.group(3).strip().strip('"').strip()
+    a, b = int(m.group(4)), int(m.group(5))
+    if b < a or b - a > 30:
+        return [raw]
+    return [f'{base} ({i})' for i in range(a, b + 1)]
+
+
+def write_output(manga: str, source_url: str, volumes: list[dict], path: str):
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(f"Title: {manga}\n")
+        f.write(f"Source: {source_url}\n\n")
+        global_n = 0
+        for v in volumes:
+            count = sum(len(expand_chapter(ch)) for ch in v["chapters"])
+            if count == 0:
+                f.write(f"v{v['volume']}: -\n")
+                continue
+            start = global_n + 1
+            end = global_n + count
+            global_n = end
+            if start == end:
+                f.write(f"v{v['volume']}: {start}\n")
+            else:
+                f.write(f"v{v['volume']}: {start}-{end}\n")
+
+
+def run(name, dest_path, console):
+    # validate if manga has wikipedia page 
+    console.print(f"Validating '{name}' as a manga on Wikipedia...")
+    title = validate_manga(name)
+    if not title:
+        console.print(f"Error '{name}' does not appear to be a valid manga on Wikipedia.\n"
+                      f"No file was written. Manual lookup required.")
+        return False
+    console.print(f"Validated manga: {title}")
+    
+    # find chapters page of manga
+    base = re.sub(r"\s*\(manga\)\s*$", "", title, flags=re.I)
+    chapters_title = (
+        find_chapters_page(base, manga_title=title)
+        or find_chapters_page(name, manga_title=title)
+        or _page_exists(title)
+    )
+    if not chapters_title:
+        console.print("Error: could not find a chapters page on Wikipedia.\n"
+                      "No file was written. Manual lookup required.")
+        return False
+    console.print(f"Chapters page: {chapters_title}")
+
+    #clear
+    url = f"{WIKI}/wiki/{urllib.parse.quote(chapters_title.replace(' ', '_'))}"
+    html = fetch(url)
+    volumes = extract_volumes(html)
+    total_ch = sum(sum(len(expand_chapter(c)) for c in v['chapters']) for v in volumes)
+    console.print(f"Parsed {len(volumes)} volume(s), {total_ch} chapter(s)")
+
+    if not volumes or total_ch == 0:
+        console.print(f"Error: no volumes/chapters could be parsed from {url}\n"
+                      f"No file was written. Manual lookup required.")
+        return False
+    
+    out = dest_path or f"{re.sub(r'[^A-Za-z0-9]+', '_', name).strip('_')}_chapters.txt"
+    write_output(title, url, volumes, out)
+    console.print(f"Wrote: {out}")
+    return True


### PR DESCRIPTION
Add a new command that helps with automating the creation of the volume interval file. 
This command, given the name of a manga, scrapes various Wikipedia pages to find which chapters are in a volume for that manga. 
Added a verbose flag, for further and detailed information, without it, the output file is just a comma separated chapter cutoff list. 
closes: #24 